### PR TITLE
Fixed System.ArgumentOutOfRangeException in GetTimestamp(Location location) function

### DIFF
--- a/samples/GeolocatorSample/GeolocatorSample.Droid/GeolocatorSample.Droid.csproj
+++ b/samples/GeolocatorSample/GeolocatorSample.Droid/GeolocatorSample.Droid.csproj
@@ -24,7 +24,7 @@
     <JavaOptions />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Geolocator.Plugin.Android/GeolocatorImplementation.cs
+++ b/src/Geolocator.Plugin.Android/GeolocatorImplementation.cs
@@ -282,7 +282,14 @@ namespace Plugin.Geolocator
         private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         internal static DateTimeOffset GetTimestamp(Location location)
         {
-            return new DateTimeOffset(Epoch.AddMilliseconds(location.Time));
+            try
+            {
+                return new DateTimeOffset(Epoch.AddMilliseconds(location.Time));
+            }
+            catch (Exception e)
+            {
+                return new DateTimeOffset(Epoch);
+            }
         }
     }
 }


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes # .
System.ArgumentOutOfRangeException in GetTimestamp(Location location) function 

Changes Proposed in this pull request:
- I ported my Xamarin.Forms Android app to Blackberry. Blackberry has different implementation of geolocation timestamp and it throws:  System.ArgumentOutOfRangeException: Value to add was out of range.
- I added the code to catch Exception in GetTimestamp function. 
- Would it be possible to add this code there?

Stacktrace:

Xamarin caused by: android.runtime.JavaProxyThrowable: System.ArgumentOutOfRangeException: Value to add was out of range.
Parameter name: value
System.DateTime.Add(double value, int scale)<16a7416bd09c40d490b4ab3409bbe300>:0
System.DateTime.AddMilliseconds(double value)<16a7416bd09c40d490b4ab3409bbe300>:0
Plugin.Geolocator.GeolocatorImplementation.GetTimestamp(Location location)<26e03d55b8014460a35b5ef9e458b543>:0
Plugin.Geolocator.GeolocationSingleListener.Finish(Location location)<26e03d55b8014460a35b5ef9e458b543>:0
Plugin.Geolocator.GeolocationSingleListener.TimesUp(object state)<26e03d55b8014460a35b5ef9e458b543>:0
System.Threading.Timer.Scheduler.TimerCB(object o)<16a7416bd09c40d490b4ab3409bbe300>:0
System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()<16a7416bd09c40d490b4ab3409bbe300>:0
System.Threading.ThreadPoolWorkQueue.Dispatch()<16a7416bd09c40d490b4ab3409bbe300>:0
System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()<16a7416bd09c40d490b4ab3409bbe300>:0
dalvik.system.NativeStart.run(Native Method)
