### PR TITLE
Check permission before getting position [iOS]

### DIFF
--- a/src/Geolocator.Plugin.iOSUnified/Geolocator.Plugin.iOSUnified.csproj
+++ b/src/Geolocator.Plugin.iOSUnified/Geolocator.Plugin.iOSUnified.csproj
@@ -48,10 +48,19 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Plugin.Permissions, Version=1.1.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Plugin.Permissions.1.1.7\lib\Xamarin.iOS10\Plugin.Permissions.dll</HintPath>
+    </Reference>
+    <Reference Include="Plugin.Permissions.Abstractions, Version=1.1.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Plugin.Permissions.1.1.7\lib\Xamarin.iOS10\Plugin.Permissions.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="..\Geolocator.Shared\Geolocator.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/src/Geolocator.Plugin.iOSUnified/packages.config
+++ b/src/Geolocator.Plugin.iOSUnified/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Plugin.Permissions" version="1.1.7" targetFramework="xamarinios10" />
+</packages>


### PR DESCRIPTION
The iOS implementation explicitly request authorization to the location inside the constructor.
That means the "dialog authorization" of the phone is displayed during loading.

I made things different, as Android do.
I noticed that you used your "Permission plugin" in Droid project to check permission before getting position.
So, I made the same things on iOS.

Changes Proposed in this pull request:
- No more popup on load (remove the RequestAuthorize call in the cstor)
- Check permission before getting position (result in displaying popup only when user ask for the position)

Let me know what you think :)