### PR TITLE
Apply DesiredAccuracy to CLLocationManager when calling GetPositionAsync

### DIFF
--- a/src/Geolocator.Plugin.iOSUnified/GeolocatorImplementation.cs
+++ b/src/Geolocator.Plugin.iOSUnified/GeolocatorImplementation.cs
@@ -213,7 +213,7 @@ namespace Plugin.Geolocator
             if (!IsListening)
             {
                 var m = GetManager();
-
+                m.DesiredAccuracy = DesiredAccuracy;
 #if __IOS__
                 // permit background updates if background location mode is enabled
                 if (UIDevice.CurrentDevice.CheckSystemVersion(9, 0))


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes:

#43 
this will improve the speed of location fixe when not requesting a high accuracy,

 #Changes Proposed in this pull request:
- Apply the desired accuracy to CLLocationManager when calling GetPositionAsync
