### PR TITLE
Support LocationUpdatesPaused 

### DIFF
--- a/docs/BackgroundUpdates.md
+++ b/docs/BackgroundUpdates.md
@@ -75,6 +75,8 @@ async Task StartListening()
 }
 ```
 
+For iOS if ```PauseLocationUpdatesAutomatically``` is set to ```true``` then the corresponding event, ```PositionUpdatesPaused```, will be raised when the OS is pausing the background tracking. It's the responsability of the app to restart the tracking, see [Apple documentation](https://developer.apple.com/documentation/corelocation/cllocationmanager/1620553-pauseslocationupdatesautomatical)
+
 ### Android
 For this you will want to integrate a foreground service that subscribes to location changes and the user interface binds to. Please read through the [Xamarin.Android Services documentation](https://developer.xamarin.com/guides/android/application_fundamentals/services/)
 

--- a/src/Geolocator.Plugin.Abstractions/IGeolocator.cs
+++ b/src/Geolocator.Plugin.Abstractions/IGeolocator.cs
@@ -20,6 +20,11 @@ namespace Plugin.Geolocator.Abstractions
         /// </summary>
         event EventHandler<PositionEventArgs> PositionChanged;
 
+		/// <summary>
+		/// Position updates paused event handler, only raised on iOS
+		/// </summary>
+		event EventHandler PositionUpdatesPaused;
+
         /// <summary>
         /// Desired accuracy in meters
         /// </summary>

--- a/src/Geolocator.Plugin.Android/GeolocatorImplementation.cs
+++ b/src/Geolocator.Plugin.Android/GeolocatorImplementation.cs
@@ -56,6 +56,8 @@ namespace Plugin.Geolocator
 		/// <inheritdoc/>
 		public event EventHandler<PositionEventArgs> PositionChanged;
 		/// <inheritdoc/>
+		public event EventHandler PositionUpdatesPaused;
+		/// <inheritdoc/>
 		public bool IsListening => listener != null;
 
 

--- a/src/Geolocator.Plugin.UWP/GeolocatorImplementation.cs
+++ b/src/Geolocator.Plugin.UWP/GeolocatorImplementation.cs
@@ -37,6 +37,9 @@ namespace Plugin.Geolocator
         /// </summary>
         public event EventHandler<PositionErrorEventArgs> PositionError;
 
+		/// <inheritdoc/>
+		public event EventHandler PositionUpdatesPaused;
+
         /// <summary>
         /// Gets if device supports heading
         /// </summary>

--- a/src/Geolocator.Plugin.iOSUnified/GeolocatorImplementation.cs
+++ b/src/Geolocator.Plugin.iOSUnified/GeolocatorImplementation.cs
@@ -100,6 +100,12 @@ namespace Plugin.Geolocator
         /// </summary>
         public event EventHandler<PositionEventArgs> PositionChanged;
 
+		/// <summary>
+		/// Position updates have been paused by the OS, it's the responsability of the app to restart the tracking
+		/// see https://developer.apple.com/documentation/corelocation/cllocationmanager/1620553-pauseslocationupdatesautomatical 
+		/// </summary>
+		public event EventHandler PositionUpdatesPaused;
+
         /// <summary>
         /// Desired accuracy in meters
         /// </summary>
@@ -388,6 +394,11 @@ namespace Plugin.Geolocator
             if (UIDevice.CurrentDevice.CheckSystemVersion(6, 0))
             {
                 manager.PausesLocationUpdatesAutomatically = listenerSettings.PauseLocationUpdatesAutomatically;
+
+                if(manager.PausesLocationUpdatesAutomatically)
+                {
+                    manager.LocationUpdatesPaused += (sender, e) => PositionUpdatesPaused?.Invoke(this, e);
+                }
 
                 switch(listenerSettings.ActivityType)
                 {

--- a/src/Geolocator.Plugin.iOSUnified/GeolocatorImplementation.cs
+++ b/src/Geolocator.Plugin.iOSUnified/GeolocatorImplementation.cs
@@ -397,7 +397,7 @@ namespace Plugin.Geolocator
 
                 if(manager.PausesLocationUpdatesAutomatically)
                 {
-                    manager.LocationUpdatesPaused += (sender, e) => PositionUpdatesPaused?.Invoke(this, e);
+                    manager.LocationUpdatesPaused += OnLocationUpdatesPaused; 
                 }
 
                 switch(listenerSettings.ActivityType)
@@ -447,6 +447,11 @@ namespace Plugin.Geolocator
             return true;
         }
 
+        void OnLocationUpdatesPaused(object sender, EventArgs e)
+        {
+            PositionUpdatesPaused?.Invoke(this, e);
+        }
+
         /// <summary>
         /// Stop listening
         /// </summary>
@@ -459,6 +464,11 @@ namespace Plugin.Geolocator
 #if __IOS__
             if (CLLocationManager.HeadingAvailable)
                 manager.StopUpdatingHeading();
+
+			if (manager.PausesLocationUpdatesAutomatically)
+			{
+				manager.LocationUpdatesPaused -= OnLocationUpdatesPaused;
+			}
 
             // it looks like deferred location updates can apply to the standard service or significant change service. disallow deferral in either case.
             if ((listenerSettings?.DeferLocationUpdates ?? false) && CanDeferLocationUpdate)


### PR DESCRIPTION
No issue reported. It was more a change we wanted to bring back from the development of our app.

Changes Proposed in this pull request:
- Subscribe and expose the LocationUpdatesPaused event of the CLocationManager on iOS so the app can restart the tracking as it's described here https://developer.apple.com/documentation/corelocation/cllocationmanager/1620553-pauseslocationupdatesautomatical
