### PR TITLE
Android: limiting location providers doesn't work: it does opposite of what was needed (user selec…

### DIFF
--- a/src/Geolocator.Plugin.Android/GeolocatorImplementation.cs
+++ b/src/Geolocator.Plugin.Android/GeolocatorImplementation.cs
@@ -167,10 +167,8 @@ namespace Plugin.Geolocator
 					//only add providers requested.
 					foreach (var provider in Providers)
 					{
-						if (ProvidersToUse?.Contains(provider) ?? false)
-							continue;
-
-						providers.Add(provider);
+						if (ProvidersToUse.Contains(provider))
+							providers.Add(provider);
 					}
 				}
 				


### PR DESCRIPTION
Hi James,

on Android limiting location providers to 'gps' actually does opposite
and all providers except 'gps' are enabled.

Regards,
Aleksandar