### PR TITLE
Include HasAltitude, HasBearing, HasSpeed, and HasAccuracy in Position

### DIFF
--- a/src/Geolocator.Plugin/Abstractions/Position.shared.cs
+++ b/src/Geolocator.Plugin/Abstractions/Position.shared.cs
@@ -26,12 +26,17 @@ namespace Plugin.Geolocator.Abstractions
                 throw new ArgumentNullException("position");
 
             Timestamp = position.Timestamp;
+			HasLatitudeLongitude = position.HasLatitudeLongitude;
             Latitude = position.Latitude;
             Longitude = position.Longitude;
+			HasAltitude = position.HasAltitude;
             Altitude = position.Altitude;
             AltitudeAccuracy = position.AltitudeAccuracy;
+			HasAccuracy = position.HasAccuracy;
             Accuracy = position.Accuracy;
+			HasHeading = position.HasAccuracy;
             Heading = position.Heading;
+			HasSpeed = position.HasSpeed;
             Speed = position.Speed;
 			IsFromMockProvider = position.IsFromMockProvider;
         }
@@ -44,6 +49,15 @@ namespace Plugin.Geolocator.Abstractions
             get;
             set;
         }
+
+		/// <summary>
+		/// Specifies if the Latitude and Longitude values are valid
+		/// </summary>
+		public bool HasLatitudeLongitude
+		{
+			get;
+			set;
+		}
 
         /// <summary>
         /// Gets or sets the latitude.
@@ -63,19 +77,37 @@ namespace Plugin.Geolocator.Abstractions
             set;
         }
 
-        /// <summary>
-        /// Gets or sets the altitude in meters relative to sea level.
-        /// </summary>
-        public double Altitude
+		/// <summary>
+		/// Specifies if the Altitude value is valid
+		/// </summary>
+		public bool HasAltitude
+		{
+			get;
+			set;
+		}
+
+		/// <summary>
+		/// Gets or sets the altitude in meters relative to sea level.
+		/// </summary>
+		public double Altitude
         {
             get;
             set;
         }
 
-        /// <summary>
-        /// Gets or sets the potential position error radius in meters.
-        /// </summary>
-        public double Accuracy
+		/// <summary>
+		/// Specifies if the Accuracy value is valid
+		/// </summary>
+		public bool HasAccuracy
+		{
+			get;
+			set;
+		}
+
+		/// <summary>
+		/// Gets or sets the potential position error radius in meters.
+		/// </summary>
+		public double Accuracy
         {
             get;
             set;
@@ -93,19 +125,37 @@ namespace Plugin.Geolocator.Abstractions
             set;
         }
 
-        /// <summary>
-        /// Gets or sets the heading in degrees relative to true North.
-        /// </summary>
-        public double Heading
+		/// <summary>
+		/// Specifies if the Heading value is valid
+		/// </summary>
+		public bool HasHeading
+		{
+			get;
+			set;
+		}
+
+		/// <summary>
+		/// Gets or sets the heading in degrees relative to true North.
+		/// </summary>
+		public double Heading
         {
             get;
             set;
         }
 
-        /// <summary>
-        /// Gets or sets the speed in meters per second.
-        /// </summary>
-        public double Speed
+		/// <summary>
+		/// Specifies if the Speed value is valid
+		/// </summary>
+		public bool HasSpeed
+		{
+			get;
+			set;
+		}
+
+		/// <summary>
+		/// Gets or sets the speed in meters per second.
+		/// </summary>
+		public double Speed
         {
             get;
             set;

--- a/src/Geolocator.Plugin/Android/GeolocationUtils.android.cs
+++ b/src/Geolocator.Plugin/Android/GeolocationUtils.android.cs
@@ -61,16 +61,25 @@ namespace Plugin.Geolocator
         internal static Position ToPosition(this Location location)
         {
             var p = new Position();
-            if (location.HasAccuracy)
+			
+			p.HasAccuracy = location.HasAccuracy;
+			if (location.HasAccuracy)
                 p.Accuracy = location.Accuracy;
-            if (location.HasAltitude)
+
+			p.HasAltitude = location.HasAltitude;
+			if (location.HasAltitude)
                 p.Altitude = location.Altitude;
-            if (location.HasBearing)
+
+			p.HasHeading = location.HasBearing;
+			if (location.HasBearing)
                 p.Heading = location.Bearing;
-            if (location.HasSpeed)
+
+			p.HasSpeed = location.HasSpeed;
+			if (location.HasSpeed)
                 p.Speed = location.Speed;
 
-            p.Longitude = location.Longitude;
+			p.HasLatitudeLongitude = true;
+			p.Longitude = location.Longitude;
             p.Latitude = location.Latitude;
             p.Timestamp = location.GetTimestamp();
 

--- a/src/Geolocator.Plugin/Apple/GeolocationSingleUpdateDelegate.apple.cs
+++ b/src/Geolocator.Plugin/Apple/GeolocationSingleUpdateDelegate.apple.cs
@@ -109,20 +109,25 @@ namespace Plugin.Geolocator
             if (haveLocation && newLocation.HorizontalAccuracy > position.Accuracy)
                 return;
 
+			position.HasAccuracy = true;
             position.Accuracy = newLocation.HorizontalAccuracy;
-            position.Altitude = newLocation.Altitude;
+			position.HasAltitude = newLocation.VerticalAccuracy >= 0;
+			position.Altitude = newLocation.Altitude;
             position.AltitudeAccuracy = newLocation.VerticalAccuracy;
-            position.Latitude = newLocation.Coordinate.Latitude;
+			position.HasLatitudeLongitude = newLocation.HorizontalAccuracy >= 0;
+			position.Latitude = newLocation.Coordinate.Latitude;
             position.Longitude = newLocation.Coordinate.Longitude;
 #if __IOS__ || __MACOS__
-            position.Speed = newLocation.Speed;
+			position.HasSpeed = newLocation.Speed >= 0;
+			position.Speed = newLocation.Speed;
 			if (includeHeading)
 			{
+				position.HasHeading = newLocation.Course >= 0;
 				position.Heading = newLocation.Course;
 			}
 #endif
 			try
-            {
+			{
                 position.Timestamp = new DateTimeOffset(newLocation.Timestamp.ToDateTime());
             }
             catch(Exception ex)

--- a/src/Geolocator.Plugin/Apple/GeolocationSingleUpdateDelegate.apple.cs
+++ b/src/Geolocator.Plugin/Apple/GeolocationSingleUpdateDelegate.apple.cs
@@ -111,18 +111,18 @@ namespace Plugin.Geolocator
 
 			position.HasAccuracy = true;
             position.Accuracy = newLocation.HorizontalAccuracy;
-			position.HasAltitude = newLocation.VerticalAccuracy >= 0;
+			position.HasAltitude = newLocation.VerticalAccuracy > -1;
 			position.Altitude = newLocation.Altitude;
             position.AltitudeAccuracy = newLocation.VerticalAccuracy;
-			position.HasLatitudeLongitude = newLocation.HorizontalAccuracy >= 0;
+			position.HasLatitudeLongitude = newLocation.HorizontalAccuracy > -1;
 			position.Latitude = newLocation.Coordinate.Latitude;
             position.Longitude = newLocation.Coordinate.Longitude;
 #if __IOS__ || __MACOS__
-			position.HasSpeed = newLocation.Speed >= 0;
+			position.HasSpeed = newLocation.Speed > -1;
 			position.Speed = newLocation.Speed;
 			if (includeHeading)
 			{
-				position.HasHeading = newLocation.Course >= 0;
+				position.HasHeading = newLocation.Course > -1;
 				position.Heading = newLocation.Course;
 			}
 #endif

--- a/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
+++ b/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
@@ -216,15 +216,15 @@ namespace Plugin.Geolocator
 			var position = new Position();
 			position.HasAccuracy = true;
 			position.Accuracy = newLocation.HorizontalAccuracy;
-			position.HasAltitude = newLocation.Altitude >= 0;
+			position.HasAltitude = newLocation.Altitude > -1;
 			position.Altitude = newLocation.Altitude;
 			position.AltitudeAccuracy = newLocation.VerticalAccuracy;
-			position.HasLatitudeLongitude = newLocation.HorizontalAccuracy >= 0;
+			position.HasLatitudeLongitude = newLocation.HorizontalAccuracy > -1;
 			position.Latitude = newLocation.Coordinate.Latitude;
 			position.Longitude = newLocation.Coordinate.Longitude;
 
 #if !__TVOS__
-			position.HasSpeed = newLocation.Speed >= 0;
+			position.HasSpeed = newLocation.Speed > -1;
 			position.Speed = newLocation.Speed;
 #endif
 
@@ -519,7 +519,7 @@ namespace Plugin.Geolocator
 			var p = (lastPosition == null) ? new Position() : new Position(this.lastPosition);
 			p.HasAccuracy = true;
 
-			if (location.HorizontalAccuracy >= 0)
+			if (location.HorizontalAccuracy > -1)
 			{
 				p.Accuracy = location.HorizontalAccuracy;
 				p.HasLatitudeLongitude = true;
@@ -527,7 +527,7 @@ namespace Plugin.Geolocator
 				p.Longitude = location.Coordinate.Longitude;
 			}
 
-			if (location.VerticalAccuracy >= 0)
+			if (location.VerticalAccuracy > -1)
 			{
 				p.HasAltitude = true;
 				p.Altitude = location.Altitude;
@@ -535,14 +535,14 @@ namespace Plugin.Geolocator
 			}
 
 #if __IOS__ || __MACOS__
-            if (location.Speed >= 0)
+            if (location.Speed > -1)
 			{
 				p.HasSpeed = true;
 				p.Speed = location.Speed;
 			}
                 
 
-			if (includeHeading && location.Course >= 0)
+			if (includeHeading && location.Course > -1)
 			{
 				p.HasHeading = true;
 				p.Heading = location.Course;

--- a/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
+++ b/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
@@ -214,13 +214,17 @@ namespace Plugin.Geolocator
 				return null;
 
 			var position = new Position();
+			position.HasAccuracy = true;
 			position.Accuracy = newLocation.HorizontalAccuracy;
+			position.HasAltitude = newLocation.Altitude >= 0;
 			position.Altitude = newLocation.Altitude;
 			position.AltitudeAccuracy = newLocation.VerticalAccuracy;
+			position.HasLatitudeLongitude = newLocation.HorizontalAccuracy >= 0;
 			position.Latitude = newLocation.Coordinate.Latitude;
 			position.Longitude = newLocation.Coordinate.Longitude;
 
 #if !__TVOS__
+			position.HasSpeed = newLocation.Speed >= 0;
 			position.Speed = newLocation.Speed;
 #endif
 
@@ -328,6 +332,7 @@ namespace Plugin.Geolocator
 				var positionList = await geocoder.GeocodeAddressAsync(address);
 				return positionList.Select(p => new Position
 				{
+					HasLatitudeLongitude = true,
 					Latitude = p.Location.Coordinate.Latitude,
 					Longitude = p.Location.Coordinate.Longitude
 				});
@@ -512,26 +517,36 @@ namespace Plugin.Geolocator
 		void UpdatePosition(CLLocation location)
 		{
 			var p = (lastPosition == null) ? new Position() : new Position(this.lastPosition);
+			p.HasAccuracy = true;
 
-			if (location.HorizontalAccuracy > -1)
+			if (location.HorizontalAccuracy >= 0)
 			{
 				p.Accuracy = location.HorizontalAccuracy;
+				p.HasLatitudeLongitude = true;
 				p.Latitude = location.Coordinate.Latitude;
 				p.Longitude = location.Coordinate.Longitude;
 			}
 
-			if (location.VerticalAccuracy > -1)
+			if (location.VerticalAccuracy >= 0)
 			{
+				p.HasAltitude = true;
 				p.Altitude = location.Altitude;
 				p.AltitudeAccuracy = location.VerticalAccuracy;
 			}
 
 #if __IOS__ || __MACOS__
-            if (location.Speed > -1)
-                p.Speed = location.Speed;
+            if (location.Speed >= 0)
+			{
+				p.HasSpeed = true;
+				p.Speed = location.Speed;
+			}
+                
 
-			if (includeHeading && location.Course > -1)
+			if (includeHeading && location.Course >= 0)
+			{
+				p.HasHeading = true;
 				p.Heading = location.Course;
+			}
 #endif
 
 			try

--- a/src/Geolocator.Plugin/UWP/GeolocatorImplementation.uwp.cs
+++ b/src/Geolocator.Plugin/UWP/GeolocatorImplementation.uwp.cs
@@ -327,23 +327,33 @@ namespace Plugin.Geolocator
 
         private static Position GetPosition(Geoposition position)
         {
-            var pos = new Position
-            {
+			var pos = new Position
+			{
+				HasAccuracy = true,
                 Accuracy = position.Coordinate.Accuracy,
+				HasLatitudeLongitude = true,
                 Latitude = position.Coordinate.Point.Position.Latitude,
                 Longitude = position.Coordinate.Point.Position.Longitude,
                 Timestamp = position.Coordinate.Timestamp.ToUniversalTime(),
             };
 
+
             if (position.Coordinate.Heading != null)
-                pos.Heading = position.Coordinate.Heading.Value;
+			{
+				pos.HasHeading = true;
+				pos.Heading = position.Coordinate.Heading.Value;
+			}
 
             if (position.Coordinate.Speed != null)
-                pos.Speed = position.Coordinate.Speed.Value;
+			{
+				pos.HasSpeed = true;
+				pos.Speed = position.Coordinate.Speed.Value;
+			}
 
             if (position.Coordinate.AltitudeAccuracy.HasValue)
                 pos.AltitudeAccuracy = position.Coordinate.AltitudeAccuracy.Value;
 
+			pos.HasAltitude = position.Coordinate.Point.AltitudeReferenceSystem != AltitudeReferenceSystem.Unspecified;
             pos.Altitude = position.Coordinate.Point.Position.Altitude;
 
             return pos;

--- a/src/Tests/GeolocatorTests/HomePage.xaml
+++ b/src/Tests/GeolocatorTests/HomePage.xaml
@@ -50,8 +50,8 @@
 	<ContentPage Title="Tracking">
 		<Grid>
 			<Grid.RowDefinitions>
-				<RowDefinition Height=".65*"/>
-				<RowDefinition Height=".35*"/>
+				<RowDefinition Height=".72*"/>
+				<RowDefinition Height=".28*"/>
 			</Grid.RowDefinitions>
 			<ScrollView Grid.Row="0">
 				<StackLayout Spacing="10" Padding="10">

--- a/src/Tests/GeolocatorTests/HomePage.xaml.cs
+++ b/src/Tests/GeolocatorTests/HomePage.xaml.cs
@@ -49,9 +49,10 @@ namespace GeolocatorTests
 
 				savedPosition = position;
 				ButtonAddressForPosition.IsEnabled = true;
-				LabelCached.Text = string.Format("Time: {0} \nLat: {1} \nLong: {2} \nAltitude: {3} \nAltitude Accuracy: {4} \nAccuracy: {5} \nHeading: {6} \nSpeed: {7}",
+				LabelCached.Text = string.Format("Time: {0} \nHas Lat Lon: {8}\nLat: {1} \nLong: {2} \nHas Altitude: {9}\nAltitude: {3} \nAltitude Accuracy: {4} \nHas Accuracy: {10}\nAccuracy: {5} \nHas Heading: {11}\nHeading: {6} \nHas Speed: {12}\nSpeed: {7}",
 					position.Timestamp, position.Latitude, position.Longitude,
-					position.Altitude, position.AltitudeAccuracy, position.Accuracy, position.Heading, position.Speed);
+					position.Altitude, position.AltitudeAccuracy, position.Accuracy, position.Heading, position.Speed,
+					position.HasLatitudeLongitude, position.HasAltitude, position.HasAccuracy, position.HasHeading, position.HasSpeed);
 
 			}
 			catch (Exception ex)
@@ -87,9 +88,11 @@ namespace GeolocatorTests
 				}
 				savedPosition = position;
 				ButtonAddressForPosition.IsEnabled = true;
-				labelGPS.Text = string.Format("Time: {0} \nLat: {1} \nLong: {2} \nAltitude: {3} \nAltitude Accuracy: {4} \nAccuracy: {5} \nHeading: {6} \nSpeed: {7}",
+
+				labelGPS.Text = string.Format("Time: {0} \nHas Lat Lon: {8}\nLat: {1} \nLong: {2} \nHas Altitude: {9}\nAltitude: {3} \nAltitude Accuracy: {4} \nHas Accuracy: {10}\nAccuracy: {5} \nHas Heading: {11}\nHeading: {6} \nHas Speed: {12}\nSpeed: {7}",
 					position.Timestamp, position.Latitude, position.Longitude,
-					position.Altitude, position.AltitudeAccuracy, position.Accuracy, position.Heading, position.Speed);
+					position.Altitude, position.AltitudeAccuracy, position.Accuracy, position.Heading, position.Speed,
+					position.HasLatitudeLongitude, position.HasAltitude, position.HasAccuracy, position.HasHeading, position.HasSpeed);
 
 			}
 			catch (Exception ex)
@@ -242,11 +245,14 @@ namespace GeolocatorTests
 				Positions.Add(position);
 				count++;
 				LabelCount.Text = $"{count} updates";
-				labelGPSTrack.Text = string.Format("Time: {0} \nLat: {1} \nLong: {2} \nAltitude: {3} \nAltitude Accuracy: {4} \nAccuracy: {5} \nHeading: {6} \nSpeed: {7}",
+
+				labelGPSTrack.Text = string.Format("Time: {0} \nHas Lat Lon: {8}\nLat: {1} \nLong: {2} \nHas Altitude: {9}\nAltitude: {3} \nAltitude Accuracy: {4} \nHas Accuracy: {10}\nAccuracy: {5} \nHas Heading: {11}\nHeading: {6} \nHas Speed: {12}\nSpeed: {7}",
 					position.Timestamp, position.Latitude, position.Longitude,
-					position.Altitude, position.AltitudeAccuracy, position.Accuracy, position.Heading, position.Speed);
+					position.Altitude, position.AltitudeAccuracy, position.Accuracy, position.Heading, position.Speed,
+					position.HasLatitudeLongitude, position.HasAltitude, position.HasAccuracy, position.HasHeading, position.HasSpeed);
 
 			});
 		}
 	}
 }
+ 


### PR DESCRIPTION
Fixes # 310.

Changes Proposed in this pull request:
- Include HasAltitude, HasBearing, HasSpeed, and HasAccuracy in Position object
- Modify iOS's valid speed & bearing checks from `> -1` to `>= 0` _(per Apple docs mentioning invalid values being any negative number and the data type is double)_

&nbsp;

Implementation approach:
- HasLongitudeLatitude
  - Android
    - assign: true always
    - from Google docs: All locations generated by the LocationManager will have a valid latitude.
    - from Google docs: All locations generated by the LocationManager will have a valid longitude.
  - iOS
    - assign: CLLocation::horizontalAccuracy >= 0
    - from Apple docs: A negative value indicates that the latitude and longitude are invalid.
  - UWP
    - assign: true always
    - from MS docs: Values for the Latitude, Longitude, and Accuracy properties are always provided

- HasAltitude
  - Android
    - assign: (bool)Location::hasAltitude()
  - iOS
    - CLLocation::verticalAccuracy >= 0
    - from Apple docs: When this property contains a negative number, the value in the altitude property is invalid.
  - UWP
    - assign: Geoposition::Coordinate::Point::AltitudeReferenceSystem != AltitudeReferenceSystem.Unspecified
    - This one is a bit cryptic to me based upon the docs
    - from MS docs for Altitude: This field has an effect only if you set the altitude reference system of class that you create by using this BasicGeoPosition (For example: The AltitudeReferenceSystem property of a Geopoint ).

- HasAccuracy
  - Android
    - assign: (bool)Android::hasAccuracy()
  - iOS
    - assign: Always true
  - UWP
    - assign: true always
    - from MS docs: Values for the Latitude, Longitude, and Accuracy properties are always provided

- HasHeading
  - Android
    - assign: (bool)Location::hasBearing()
  - iOS
    - assign: (bool) CLLocation::course >= 0
    - from Apple docs: A negative value indicates that the course information is invalid.
  - UWP
    - assign: Geoposition::Coordinate::Heading != null
    - from MS docs: Values for the Altitude, AltitudeAccuracy, Heading, and Speed properties are provided if available

- HasSpeed
  - Android
    - assign: (bool)Location::hasSpeed()
  - iOS
    - assign: (bool) CLLocation::speed >= 0
    - from Apple docs: A negative value indicates an invalid speed
  - UWP
    - assign: Geoposition::Coordinate::Speed != null
    - from MS docs: Values for the Altitude, AltitudeAccuracy, Heading, and Speed properties are provided if available
