### PR TITLE
Exposing CLLocationManager.ShowsBackgroundLocationIndicator into ListenerSettings

### DIFF
--- a/src/Geolocator.Plugin/Abstractions/ListenerSettings.shared.cs
+++ b/src/Geolocator.Plugin/Abstractions/ListenerSettings.shared.cs
@@ -42,5 +42,11 @@ namespace Plugin.Geolocator.Abstractions
 		/// </summary>
 		/// <value>The time between updates (default:  5 minutes).</value>
 		public TimeSpan? DeferralTime { get; set; } = TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// A Boolean indicating whether the status bar changes its appearance when an app uses location services in the background. (>= iOS 11). Default: false
+        /// </summary>
+        public bool ShowsBackgroundLocationIndicator { get; set; } = false;
+
 	}
 }

--- a/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
+++ b/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
@@ -401,6 +401,9 @@ namespace Plugin.Geolocator
 
 			// set background flag
 #if __IOS__
+			if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
+				manager.ShowsBackgroundLocationIndicator = listenerSettings.ShowsBackgroundLocationIndicator;
+
 			if (UIDevice.CurrentDevice.CheckSystemVersion(9, 0))
 				manager.AllowsBackgroundLocationUpdates = listenerSettings.AllowBackgroundUpdates;
 


### PR DESCRIPTION
Changes Proposed in this pull request:
- Add a new parameter in `ListenerSettings`: 
```csharp
/// <summary>
 /// A Boolean indicating whether the status bar changes its appearance when an app uses location services in the background. (>= iOS 11). Default: false
/// </summary>
public bool ShowsBackgroundLocationIndicator { get; set; } = false;
```
Affect only iOS 11+ devices.

[Official documentation](https://developer.apple.com/documentation/corelocation/cllocationmanager/2923541-showsbackgroundlocationindicator) by Apple