### PR TITLE
Correction to iOS permission check

### DIFF
--- a/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
+++ b/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
@@ -80,18 +80,7 @@ namespace Plugin.Geolocator
 			{
 				Console.WriteLine("Currently does not have Location permissions, requesting permissions");
 
-				if (UIDevice.CurrentDevice.CheckSystemVersion(14, 0))
-				{
-					//TODO temporary workaround for iOS 14 issues with location permission changes
-					Permissions.CrossPermissions.Current.RequestPermissionAsync<Permissions.LocationWhenInUsePermission>();
-    
-					while ((status = await Permissions.CrossPermissions.Current.CheckPermissionStatusAsync<Permissions.LocationWhenInUsePermission>()) == PermissionStatus.Unknown)
-						await Task.Delay(100);
-				}
-				else
-				{
-					status = await Permissions.CrossPermissions.Current.RequestPermissionAsync<Permissions.LocationWhenInUsePermission>();
-				}
+				status = await Permissions.CrossPermissions.Current.RequestPermissionAsync<Permissions.LocationWhenInUsePermission>();
 
 				if (status != PermissionStatus.Granted)
 				{

--- a/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
+++ b/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
@@ -80,7 +80,18 @@ namespace Plugin.Geolocator
 			{
 				Console.WriteLine("Currently does not have Location permissions, requesting permissions");
 
-				status = await Permissions.CrossPermissions.Current.RequestPermissionAsync<Permissions.LocationWhenInUsePermission>();
+				if (UIDevice.CurrentDevice.CheckSystemVersion(14, 0))
+				{
+					//TODO temporary workaround for iOS 14 issues with location permission changes
+					Permissions.CrossPermissions.Current.RequestPermissionAsync<Permissions.LocationWhenInUsePermission>();
+    
+					while ((status = await Permissions.CrossPermissions.Current.CheckPermissionStatusAsync<Permissions.LocationWhenInUsePermission>()) == PermissionStatus.Unknown)
+						await Task.Delay(100);
+				}
+				else
+				{
+					status = await Permissions.CrossPermissions.Current.RequestPermissionAsync<Permissions.LocationWhenInUsePermission>();
+				}
 
 				if (status != PermissionStatus.Granted)
 				{

--- a/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
+++ b/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
@@ -380,7 +380,7 @@ namespace Plugin.Geolocator
 			var hasPermission = false;
 			if (UIDevice.CurrentDevice.CheckSystemVersion(9, 0))
 			{
-				if (listenerSettings.AllowBackgroundUpdates)
+				if (listenerSettings.ListenForSignificantChanges)
 					hasPermission = await CheckAlwaysPermissions();
 				else
 					hasPermission = await CheckWhenInUsePermission();

--- a/src/Geolocator.Plugin/Geolocator.Plugin.csproj
+++ b/src/Geolocator.Plugin/Geolocator.Plugin.csproj
@@ -61,12 +61,10 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
-    <PackageReference Include="Plugin.Permissions" Version="5.0.0-beta" />
 		<Compile Include="**\*.android.cs" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
-    <PackageReference Include="Plugin.Permissions" Version="5.0.0-beta" />
 		<Compile Include="**\*.apple.cs" />
 	</ItemGroup>
 
@@ -78,6 +76,11 @@
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.Mac')) ">
 		<Compile Include="**\*.apple.cs" />
+	</ItemGroup>
+
+
+	<ItemGroup>
+	  <PackageReference Include="Plugin.Permissions" Version="6.0.1" />
 	</ItemGroup>
 
 

--- a/src/Geolocator.Plugin/Geolocator.Plugin.csproj
+++ b/src/Geolocator.Plugin/Geolocator.Plugin.csproj
@@ -61,10 +61,12 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+    <PackageReference Include="Plugin.Permissions" Version="5.0.0-beta" />
 		<Compile Include="**\*.android.cs" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
+    <PackageReference Include="Plugin.Permissions" Version="5.0.0-beta" />
 		<Compile Include="**\*.apple.cs" />
 	</ItemGroup>
 
@@ -76,11 +78,6 @@
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.Mac')) ">
 		<Compile Include="**\*.apple.cs" />
-	</ItemGroup>
-
-
-	<ItemGroup>
-	  <PackageReference Include="Plugin.Permissions" Version="6.0.1" />
 	</ItemGroup>
 
 


### PR DESCRIPTION
Fixes #329 
In iOS, you only ever need "While in Use" permission to use "startUpdatingLocation", whether or not background updates are enabled.
The "always" permission is used for things like startMonitoringSignificantLocationChanges; services that wake up your application even if it is not running in the background or foreground.
https://developer.apple.com/documentation/corelocation/choosing_the_location_services_authorization_to_request

Changes Proposed in this pull request:
- Only check for Always permission if trying to do ListenForSignificantChanges

An alternative proposal might be to add a property to the ListenerSettings object which lets you override which type of permission check to perform. 