### PR TITLE
Bug/permission check

### DIFF
--- a/src/Geolocator.Plugin/Abstractions/ListenerSettings.shared.cs
+++ b/src/Geolocator.Plugin/Abstractions/ListenerSettings.shared.cs
@@ -48,5 +48,9 @@ namespace Plugin.Geolocator.Abstractions
 		/// </summary>
 		public bool ShowsBackgroundLocationIndicator { get; set; } = false;
 
+		/// <summary>
+		/// A boolean indicating whether Always permission should be required to start location listening
+		/// </summary>
+		public bool RequireLocationAlwaysPermission { get; set; } = false;
 	}
 }

--- a/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
+++ b/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
@@ -80,18 +80,7 @@ namespace Plugin.Geolocator
 			{
 				Console.WriteLine("Currently does not have Location permissions, requesting permissions");
 
-				if (UIDevice.CurrentDevice.CheckSystemVersion(14, 0))
-				{
-					//TODO temporary workaround for iOS 14 issues with location permission changes
-					Permissions.CrossPermissions.Current.RequestPermissionAsync<Permissions.LocationWhenInUsePermission>();
-    
-					while ((status = await Permissions.CrossPermissions.Current.CheckPermissionStatusAsync<Permissions.LocationWhenInUsePermission>()) == PermissionStatus.Unknown)
-						await Task.Delay(100);
-				}
-				else
-				{
-					status = await Permissions.CrossPermissions.Current.RequestPermissionAsync<Permissions.LocationWhenInUsePermission>();
-				}
+				status = await Permissions.CrossPermissions.Current.RequestPermissionAsync<Permissions.LocationWhenInUsePermission>();
 
 				if (status != PermissionStatus.Granted)
 				{

--- a/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
+++ b/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
@@ -361,8 +361,6 @@ namespace Plugin.Geolocator
 		/// <param name="listenerSettings">Optional settings (iOS only)</param>
 		public async Task<bool> StartListeningAsync(TimeSpan minimumTime, double minimumDistance, bool includeHeading = false, ListenerSettings listenerSettings = null)
 		{
-
-
 			if (minimumDistance < 0)
 				throw new ArgumentOutOfRangeException(nameof(minimumDistance));
 
@@ -380,10 +378,14 @@ namespace Plugin.Geolocator
 			var hasPermission = false;
 			if (UIDevice.CurrentDevice.CheckSystemVersion(9, 0))
 			{
-				if (listenerSettings.ListenForSignificantChanges)
+				if (listenerSettings.RequireLocationAlwaysPermission)
+				{
 					hasPermission = await CheckAlwaysPermissions();
+				}
 				else
+				{
 					hasPermission = await CheckWhenInUsePermission();
+				}
 			}
 
 			if (!hasPermission)

--- a/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
+++ b/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
@@ -80,7 +80,18 @@ namespace Plugin.Geolocator
 			{
 				Console.WriteLine("Currently does not have Location permissions, requesting permissions");
 
-				status = await Permissions.CrossPermissions.Current.RequestPermissionAsync<Permissions.LocationWhenInUsePermission>();
+				if (UIDevice.CurrentDevice.CheckSystemVersion(14, 0))
+				{
+					//TODO temporary workaround for iOS 14 issues with location permission changes
+					Permissions.CrossPermissions.Current.RequestPermissionAsync<Permissions.LocationWhenInUsePermission>();
+    
+					while ((status = await Permissions.CrossPermissions.Current.CheckPermissionStatusAsync<Permissions.LocationWhenInUsePermission>()) == PermissionStatus.Unknown)
+						await Task.Delay(100);
+				}
+				else
+				{
+					status = await Permissions.CrossPermissions.Current.RequestPermissionAsync<Permissions.LocationWhenInUsePermission>();
+				}
 
 				if (status != PermissionStatus.Granted)
 				{

--- a/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
+++ b/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
@@ -380,7 +380,7 @@ namespace Plugin.Geolocator
 			var hasPermission = false;
 			if (UIDevice.CurrentDevice.CheckSystemVersion(9, 0))
 			{
-				if (listenerSettings.AllowBackgroundUpdates)
+				if (listenerSettings.ListenForSignificantChanges)
 					hasPermission = await CheckAlwaysPermissions();
 				else
 					hasPermission = await CheckWhenInUsePermission();

--- a/src/Geolocator.Plugin/Geolocator.Plugin.csproj
+++ b/src/Geolocator.Plugin/Geolocator.Plugin.csproj
@@ -61,12 +61,10 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
-    <PackageReference Include="Plugin.Permissions" Version="5.0.0-beta" />
 		<Compile Include="**\*.android.cs" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
-    <PackageReference Include="Plugin.Permissions" Version="5.0.0-beta" />
 		<Compile Include="**\*.apple.cs" />
 	</ItemGroup>
 
@@ -78,6 +76,11 @@
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.Mac')) ">
 		<Compile Include="**\*.apple.cs" />
+	</ItemGroup>
+
+
+	<ItemGroup>
+	  <PackageReference Include="Plugin.Permissions" Version="6.0.1" />
 	</ItemGroup>
 
 

--- a/src/Geolocator.Plugin/Geolocator.Plugin.csproj
+++ b/src/Geolocator.Plugin/Geolocator.Plugin.csproj
@@ -61,10 +61,12 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+    <PackageReference Include="Plugin.Permissions" Version="5.0.0-beta" />
 		<Compile Include="**\*.android.cs" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
+    <PackageReference Include="Plugin.Permissions" Version="5.0.0-beta" />
 		<Compile Include="**\*.apple.cs" />
 	</ItemGroup>
 
@@ -76,11 +78,6 @@
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.Mac')) ">
 		<Compile Include="**\*.apple.cs" />
-	</ItemGroup>
-
-
-	<ItemGroup>
-	  <PackageReference Include="Plugin.Permissions" Version="6.0.1" />
 	</ItemGroup>
 
 


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes #329 and #328 

Changes Proposed in this pull request:
- Default on iOS to just checking WhenInUse permission
- Allow the programmer to override that check to require Always permission
- Programmer can also request Always permission of the user _separately_, which is closer to apple's more recent guidelines about requesting In Use and Always permission in separate stages. https://developer.apple.com/documentation/corelocation/choosing_the_location_services_authorization_to_request
