### PR TITLE
Only Process Most Recent Location

### DIFF
--- a/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
+++ b/src/Geolocator.Plugin/Apple/GeolocatorImplementation.apple.cs
@@ -492,8 +492,10 @@ namespace Plugin.Geolocator
 
 		void OnLocationsUpdated(object sender, CLLocationsUpdatedEventArgs e)
 		{
-			foreach (var location in e.Locations)
-				UpdatePosition(location);
+			if (e.Locations.Any())
+			{
+				UpdatePosition(e.Locations.Last());
+			}
 
 			// defer future location updates if requested
 			if ((listenerSettings?.DeferLocationUpdates ?? false) && !deferringUpdates && CanDeferLocationUpdate)


### PR DESCRIPTION
Please take a moment to fill out the following:

Fixes # 332

Changes Proposed in this pull request:
-Apple's `-(void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations` method declared by `CLLocationManagerDelegate` inputs an array of locations where the last location is the most recent. Previous locations in the array may be older, therefore we should only process the last one.
